### PR TITLE
Rebuilt examples with user access and hostname changes.

### DIFF
--- a/apidocs/src/resources/samples/db-check-root-user-request.json
+++ b/apidocs/src/resources/samples/db-check-root-user-request.json
@@ -1,4 +1,4 @@
-GET /v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7/root HTTP/1.1
+GET /v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa/root HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-check-root-user-request.xml
+++ b/apidocs/src/resources/samples/db-check-root-user-request.xml
@@ -1,4 +1,4 @@
-GET /v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81/root HTTP/1.1
+GET /v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e/root HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-check-root-user-response.json
+++ b/apidocs/src/resources/samples/db-check-root-user-response.json
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 21
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:34 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 {

--- a/apidocs/src/resources/samples/db-check-root-user-response.xml
+++ b/apidocs/src/resources/samples/db-check-root-user-response.xml
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 90
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:34 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 <rootEnabled xmlns="http://docs.openstack.org/database/api/v1.0">

--- a/apidocs/src/resources/samples/db-create-databases-request.json
+++ b/apidocs/src/resources/samples/db-create-databases-request.json
@@ -1,4 +1,4 @@
-POST /v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7/databases HTTP/1.1
+POST /v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa/databases HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-create-databases-request.xml
+++ b/apidocs/src/resources/samples/db-create-databases-request.xml
@@ -1,4 +1,4 @@
-POST /v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81/databases HTTP/1.1
+POST /v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e/databases HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-create-databases-response.json
+++ b/apidocs/src/resources/samples/db-create-databases-response.json
@@ -2,5 +2,5 @@ HTTP/1.1 202 Accepted
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 0
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:33 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)

--- a/apidocs/src/resources/samples/db-create-databases-response.xml
+++ b/apidocs/src/resources/samples/db-create-databases-response.xml
@@ -2,5 +2,5 @@ HTTP/1.1 202 Accepted
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 0
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:33 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)

--- a/apidocs/src/resources/samples/db-create-instance-response.json
+++ b/apidocs/src/resources/samples/db-create-instance-response.json
@@ -2,12 +2,12 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 591
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:33 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 {
     "instance": {
-        "created": "2013-03-18T19:09:17", 
+        "created": "2013-05-07T19:35:33", 
         "flavor": {
             "id": "1", 
             "links": [
@@ -21,20 +21,20 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
                 }
             ]
         }, 
-        "id": "44b277eb-39be-4921-be31-3d61b43651d7", 
+        "id": "4fc6f076-c0dc-48ee-ae38-9eabfc241efa", 
         "links": [
             {
-                "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7", 
+                "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa", 
                 "rel": "self"
             }, 
             {
-                "href": "https://ord.databases.api.rackspacecloud.com/instances/44b277eb-39be-4921-be31-3d61b43651d7", 
+                "href": "https://ord.databases.api.rackspacecloud.com/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa", 
                 "rel": "bookmark"
             }
         ], 
         "name": "json_rack_instance", 
         "status": "BUILD", 
-        "updated": "2013-03-18T19:09:17", 
+        "updated": "2013-05-07T19:35:33", 
         "volume": {
             "size": 2
         }

--- a/apidocs/src/resources/samples/db-create-instance-response.xml
+++ b/apidocs/src/resources/samples/db-create-instance-response.xml
@@ -2,13 +2,13 @@ HTTP/1.1 200 OK
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 724
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:33 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
-<instance created="2013-03-18 19:09:17.441489" id="098653ba-218b-47ce-936a-e0b749101f81" name="xml_rack_instance" status="BUILD" updated="2013-03-18 19:09:17.441606" xmlns="http://docs.openstack.org/database/api/v1.0">
+<instance created="2013-05-07 19:35:33.539799" id="6396dba7-dcb6-44eb-b829-63423c31dc9e" name="xml_rack_instance" status="BUILD" updated="2013-05-07 19:35:33.539944" xmlns="http://docs.openstack.org/database/api/v1.0">
     <links>
-        <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81" rel="self"/>
-        <link href="https://ord.databases.api.rackspacecloud.com/instances/098653ba-218b-47ce-936a-e0b749101f81" rel="bookmark"/>
+        <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e" rel="self"/>
+        <link href="https://ord.databases.api.rackspacecloud.com/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e" rel="bookmark"/>
     </links>
     <volume size="2"/>
     <flavor id="1">

--- a/apidocs/src/resources/samples/db-create-users-request.json
+++ b/apidocs/src/resources/samples/db-create-users-request.json
@@ -1,4 +1,4 @@
-POST /v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7/users HTTP/1.1
+POST /v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa/users HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7
@@ -21,6 +21,7 @@ Content-Type: application/json
                     "name": "databaseC"
                 }
             ], 
+            "host": "10.0.0.1", 
             "name": "dbuser2", 
             "password": "password"
         }, 

--- a/apidocs/src/resources/samples/db-create-users-request.xml
+++ b/apidocs/src/resources/samples/db-create-users-request.xml
@@ -1,4 +1,4 @@
-POST /v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81/users HTTP/1.1
+POST /v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e/users HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7
@@ -7,7 +7,7 @@ Content-Type: application/xml
 
 <users xmlns="http://docs.openstack.org/database/api/v1.0">
   <user password="password" name="dbuser1" database="databaseA"/>
-  <user password="password" name="dbuser2">
+  <user host="10.0.0.1" password="password" name="dbuser2">
     <databases>
       <database name="databaseB"/>
       <database name="databaseC"/>

--- a/apidocs/src/resources/samples/db-create-users-response.json
+++ b/apidocs/src/resources/samples/db-create-users-response.json
@@ -2,5 +2,5 @@ HTTP/1.1 202 Accepted
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 0
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:34 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)

--- a/apidocs/src/resources/samples/db-create-users-response.xml
+++ b/apidocs/src/resources/samples/db-create-users-response.xml
@@ -2,5 +2,5 @@ HTTP/1.1 202 Accepted
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 0
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:34 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)

--- a/apidocs/src/resources/samples/db-delete-databases-request.json
+++ b/apidocs/src/resources/samples/db-delete-databases-request.json
@@ -1,4 +1,4 @@
-DELETE /v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7/databases/testingdb HTTP/1.1
+DELETE /v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa/databases/testingdb HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-delete-databases-request.xml
+++ b/apidocs/src/resources/samples/db-delete-databases-request.xml
@@ -1,4 +1,4 @@
-DELETE /v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81/databases/oneMoreDB HTTP/1.1
+DELETE /v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e/databases/oneMoreDB HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-delete-databases-response.json
+++ b/apidocs/src/resources/samples/db-delete-databases-response.json
@@ -2,5 +2,5 @@ HTTP/1.1 202 Accepted
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 0
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:34 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)

--- a/apidocs/src/resources/samples/db-delete-databases-response.xml
+++ b/apidocs/src/resources/samples/db-delete-databases-response.xml
@@ -2,5 +2,5 @@ HTTP/1.1 202 Accepted
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 0
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:34 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)

--- a/apidocs/src/resources/samples/db-delete-instance-request.json
+++ b/apidocs/src/resources/samples/db-delete-instance-request.json
@@ -1,4 +1,4 @@
-DELETE /v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7 HTTP/1.1
+DELETE /v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-delete-instance-request.xml
+++ b/apidocs/src/resources/samples/db-delete-instance-request.xml
@@ -1,4 +1,4 @@
-DELETE /v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81 HTTP/1.1
+DELETE /v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-delete-instance-response.json
+++ b/apidocs/src/resources/samples/db-delete-instance-response.json
@@ -2,5 +2,5 @@ HTTP/1.1 202 Accepted
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 0
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:36 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)

--- a/apidocs/src/resources/samples/db-delete-instance-response.xml
+++ b/apidocs/src/resources/samples/db-delete-instance-response.xml
@@ -2,5 +2,5 @@ HTTP/1.1 202 Accepted
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 0
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:36 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)

--- a/apidocs/src/resources/samples/db-delete-users-request.json
+++ b/apidocs/src/resources/samples/db-delete-users-request.json
@@ -1,4 +1,4 @@
-DELETE /v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7/users/testuser HTTP/1.1
+DELETE /v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa/users/demouser HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-delete-users-request.xml
+++ b/apidocs/src/resources/samples/db-delete-users-request.xml
@@ -1,4 +1,4 @@
-DELETE /v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81/users/testuser HTTP/1.1
+DELETE /v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e/users/demouser HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-delete-users-response.json
+++ b/apidocs/src/resources/samples/db-delete-users-response.json
@@ -2,5 +2,5 @@ HTTP/1.1 202 Accepted
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 0
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:34 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)

--- a/apidocs/src/resources/samples/db-delete-users-response.xml
+++ b/apidocs/src/resources/samples/db-delete-users-response.xml
@@ -2,5 +2,5 @@ HTTP/1.1 202 Accepted
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 0
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:34 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)

--- a/apidocs/src/resources/samples/db-enable-root-user-request.json
+++ b/apidocs/src/resources/samples/db-enable-root-user-request.json
@@ -1,4 +1,4 @@
-POST /v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7/root HTTP/1.1
+POST /v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa/root HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-enable-root-user-request.xml
+++ b/apidocs/src/resources/samples/db-enable-root-user-request.xml
@@ -1,4 +1,4 @@
-POST /v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81/root HTTP/1.1
+POST /v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e/root HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-enable-root-user-response.json
+++ b/apidocs/src/resources/samples/db-enable-root-user-response.json
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 47
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:34 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 {

--- a/apidocs/src/resources/samples/db-enable-root-user-response.xml
+++ b/apidocs/src/resources/samples/db-enable-root-user-response.xml
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 89
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:34 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 <user name="root" password="12345" xmlns="http://docs.openstack.org/database/api/v1.0"/>

--- a/apidocs/src/resources/samples/db-flavors-by-id-response.json
+++ b/apidocs/src/resources/samples/db-flavors-by-id-response.json
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 206
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:33 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 {

--- a/apidocs/src/resources/samples/db-flavors-by-id-response.xml
+++ b/apidocs/src/resources/samples/db-flavors-by-id-response.xml
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 283
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:33 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 <flavor id="1" name="512MB Instance" ram="512" xmlns="http://docs.openstack.org/database/api/v1.0">

--- a/apidocs/src/resources/samples/db-flavors-response.json
+++ b/apidocs/src/resources/samples/db-flavors-response.json
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 1186
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:33 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 {

--- a/apidocs/src/resources/samples/db-flavors-response.xml
+++ b/apidocs/src/resources/samples/db-flavors-response.xml
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 1600
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:33 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 <flavors xmlns="http://docs.openstack.org/database/api/v1.0">

--- a/apidocs/src/resources/samples/db-grant-user-access-request.json
+++ b/apidocs/src/resources/samples/db-grant-user-access-request.json
@@ -1,17 +1,14 @@
-PUT /v1.0/1234/instances/692d8418-7a8f-47f1-8060-59846c6e024f/users/exampleuser/databases HTTP/1.1
-User-Agent: python-example-client
+PUT /v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa/users/dbuser1/databases HTTP/1.1
+User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7
 Accept: application/json
 Content-Type: application/json
 
 {
-   "databases": [
-      {
-         "name": "databaseC"
-      },
-      {
-         "name": "databaseD"
-      }
-   ]
+    "databases": [
+        {
+            "name": "databaseE"
+        }
+    ]
 }

--- a/apidocs/src/resources/samples/db-grant-user-access-request.xml
+++ b/apidocs/src/resources/samples/db-grant-user-access-request.xml
@@ -1,10 +1,11 @@
-PUT /v1.0/1234/instances/692d8418-7a8f-47f1-8060-59846c6e024f/users/testuser/databases HTTP/1.1
-User-Agent: python-example-client
+PUT /v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e/users/dbuser1/databases HTTP/1.1
+User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7
 Accept: application/xml
 Content-Type: application/xml
 
 <databases xmlns="http://docs.openstack.org/database/api/v1.0">
-    <database name="extradb"/>
+  <database name="databaseE"/>
 </databases>
+

--- a/apidocs/src/resources/samples/db-grant-user-access-response.json
+++ b/apidocs/src/resources/samples/db-grant-user-access-response.json
@@ -1,4 +1,6 @@
 HTTP/1.1 202 Accepted
 Content-Type: application/json
+Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 0
-Date: Wed, 27 Jun 2012 23:11:19 GMT
+Date: Tue, 07 May 2013 19:35:34 GMT
+Server: Jetty(8.0.y.z-SNAPSHOT)

--- a/apidocs/src/resources/samples/db-grant-user-access-response.xml
+++ b/apidocs/src/resources/samples/db-grant-user-access-response.xml
@@ -1,4 +1,6 @@
 HTTP/1.1 202 Accepted
 Content-Type: application/xml
+Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 0
-Date: Wed, 27 Jun 2012 23:11:19 GMT
+Date: Tue, 07 May 2013 19:35:34 GMT
+Server: Jetty(8.0.y.z-SNAPSHOT)

--- a/apidocs/src/resources/samples/db-instance-reboot-request.json
+++ b/apidocs/src/resources/samples/db-instance-reboot-request.json
@@ -1,4 +1,4 @@
-POST /v1.0/1234/mgmt/instances/44b277eb-39be-4921-be31-3d61b43651d7/action HTTP/1.1
+POST /v1.0/1234/mgmt/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa/action HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-instance-reboot-request.xml
+++ b/apidocs/src/resources/samples/db-instance-reboot-request.xml
@@ -1,4 +1,4 @@
-POST /v1.0/1234/mgmt/instances/098653ba-218b-47ce-936a-e0b749101f81/action HTTP/1.1
+POST /v1.0/1234/mgmt/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e/action HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-instance-reboot-response.json
+++ b/apidocs/src/resources/samples/db-instance-reboot-response.json
@@ -2,5 +2,5 @@ HTTP/1.1 202 Accepted
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 0
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:36 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)

--- a/apidocs/src/resources/samples/db-instance-reboot-response.xml
+++ b/apidocs/src/resources/samples/db-instance-reboot-response.xml
@@ -2,5 +2,5 @@ HTTP/1.1 202 Accepted
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 0
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:36 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)

--- a/apidocs/src/resources/samples/db-instance-resize-flavor-request.json
+++ b/apidocs/src/resources/samples/db-instance-resize-flavor-request.json
@@ -1,4 +1,4 @@
-POST /v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7/action HTTP/1.1
+POST /v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa/action HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-instance-resize-flavor-request.xml
+++ b/apidocs/src/resources/samples/db-instance-resize-flavor-request.xml
@@ -1,4 +1,4 @@
-POST /v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81/action HTTP/1.1
+POST /v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e/action HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-instance-resize-flavor-response.json
+++ b/apidocs/src/resources/samples/db-instance-resize-flavor-response.json
@@ -2,5 +2,5 @@ HTTP/1.1 202 Accepted
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 0
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:35 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)

--- a/apidocs/src/resources/samples/db-instance-resize-flavor-response.xml
+++ b/apidocs/src/resources/samples/db-instance-resize-flavor-response.xml
@@ -2,5 +2,5 @@ HTTP/1.1 202 Accepted
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 0
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:35 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)

--- a/apidocs/src/resources/samples/db-instance-resize-volume-request.json
+++ b/apidocs/src/resources/samples/db-instance-resize-volume-request.json
@@ -1,4 +1,4 @@
-POST /v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7/action HTTP/1.1
+POST /v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa/action HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-instance-resize-volume-request.xml
+++ b/apidocs/src/resources/samples/db-instance-resize-volume-request.xml
@@ -1,4 +1,4 @@
-POST /v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81/action HTTP/1.1
+POST /v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e/action HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-instance-resize-volume-response.json
+++ b/apidocs/src/resources/samples/db-instance-resize-volume-response.json
@@ -2,5 +2,5 @@ HTTP/1.1 202 Accepted
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 0
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:35 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)

--- a/apidocs/src/resources/samples/db-instance-resize-volume-response.xml
+++ b/apidocs/src/resources/samples/db-instance-resize-volume-response.xml
@@ -2,5 +2,5 @@ HTTP/1.1 202 Accepted
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 0
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:35 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)

--- a/apidocs/src/resources/samples/db-instance-restart-request.json
+++ b/apidocs/src/resources/samples/db-instance-restart-request.json
@@ -1,4 +1,4 @@
-POST /v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7/action HTTP/1.1
+POST /v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa/action HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-instance-restart-request.xml
+++ b/apidocs/src/resources/samples/db-instance-restart-request.xml
@@ -1,4 +1,4 @@
-POST /v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81/action HTTP/1.1
+POST /v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e/action HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-instance-restart-response.json
+++ b/apidocs/src/resources/samples/db-instance-restart-response.json
@@ -2,5 +2,5 @@ HTTP/1.1 202 Accepted
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 0
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:35 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)

--- a/apidocs/src/resources/samples/db-instance-restart-response.xml
+++ b/apidocs/src/resources/samples/db-instance-restart-response.xml
@@ -2,5 +2,5 @@ HTTP/1.1 202 Accepted
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 0
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:35 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)

--- a/apidocs/src/resources/samples/db-instance-status-detail-request.json
+++ b/apidocs/src/resources/samples/db-instance-status-detail-request.json
@@ -1,4 +1,4 @@
-GET /v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7 HTTP/1.1
+GET /v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-instance-status-detail-request.xml
+++ b/apidocs/src/resources/samples/db-instance-status-detail-request.xml
@@ -1,4 +1,4 @@
-GET /v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81 HTTP/1.1
+GET /v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-instance-status-detail-response.json
+++ b/apidocs/src/resources/samples/db-instance-status-detail-response.json
@@ -2,12 +2,12 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 621
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:34 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 {
     "instance": {
-        "created": "2013-03-18T19:09:17", 
+        "created": "2013-05-07T19:35:33", 
         "flavor": {
             "id": "1", 
             "links": [
@@ -21,20 +21,20 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
                 }
             ]
         }, 
-        "id": "44b277eb-39be-4921-be31-3d61b43651d7", 
+        "id": "4fc6f076-c0dc-48ee-ae38-9eabfc241efa", 
         "links": [
             {
-                "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7", 
+                "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa", 
                 "rel": "self"
             }, 
             {
-                "href": "https://ord.databases.api.rackspacecloud.com/instances/44b277eb-39be-4921-be31-3d61b43651d7", 
+                "href": "https://ord.databases.api.rackspacecloud.com/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa", 
                 "rel": "bookmark"
             }
         ], 
         "name": "json_rack_instance", 
         "status": "ACTIVE", 
-        "updated": "2013-03-18T19:09:17", 
+        "updated": "2013-05-07T19:35:33", 
         "volume": {
             "size": 2, 
             "used": 0.16368598397821188

--- a/apidocs/src/resources/samples/db-instance-status-detail-response.xml
+++ b/apidocs/src/resources/samples/db-instance-status-detail-response.xml
@@ -2,13 +2,13 @@ HTTP/1.1 200 OK
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 747
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:34 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
-<instance created="2013-03-18 19:09:17.441489" id="098653ba-218b-47ce-936a-e0b749101f81" name="xml_rack_instance" status="ACTIVE" updated="2013-03-18 19:09:17.513134" xmlns="http://docs.openstack.org/database/api/v1.0">
+<instance created="2013-05-07 19:35:33.539799" id="6396dba7-dcb6-44eb-b829-63423c31dc9e" name="xml_rack_instance" status="ACTIVE" updated="2013-05-07 19:35:33.803931" xmlns="http://docs.openstack.org/database/api/v1.0">
     <links>
-        <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81" rel="self"/>
-        <link href="https://ord.databases.api.rackspacecloud.com/instances/098653ba-218b-47ce-936a-e0b749101f81" rel="bookmark"/>
+        <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e" rel="self"/>
+        <link href="https://ord.databases.api.rackspacecloud.com/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e" rel="bookmark"/>
     </links>
     <volume size="2" used="0.163685983978"/>
     <flavor id="1">

--- a/apidocs/src/resources/samples/db-instances-index-pagination-response.json
+++ b/apidocs/src/resources/samples/db-instances-index-pagination-response.json
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 1172
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:34 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 {
@@ -21,18 +21,18 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
                     }
                 ]
             }, 
-            "id": "098653ba-218b-47ce-936a-e0b749101f81", 
+            "id": "4fc6f076-c0dc-48ee-ae38-9eabfc241efa", 
             "links": [
                 {
-                    "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81", 
+                    "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa", 
                     "rel": "self"
                 }, 
                 {
-                    "href": "https://ord.databases.api.rackspacecloud.com/instances/098653ba-218b-47ce-936a-e0b749101f81", 
+                    "href": "https://ord.databases.api.rackspacecloud.com/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa", 
                     "rel": "bookmark"
                 }
             ], 
-            "name": "xml_rack_instance", 
+            "name": "json_rack_instance", 
             "status": "ACTIVE", 
             "volume": {
                 "size": 2
@@ -52,18 +52,18 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
                     }
                 ]
             }, 
-            "id": "44b277eb-39be-4921-be31-3d61b43651d7", 
+            "id": "6396dba7-dcb6-44eb-b829-63423c31dc9e", 
             "links": [
                 {
-                    "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7", 
+                    "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e", 
                     "rel": "self"
                 }, 
                 {
-                    "href": "https://ord.databases.api.rackspacecloud.com/instances/44b277eb-39be-4921-be31-3d61b43651d7", 
+                    "href": "https://ord.databases.api.rackspacecloud.com/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e", 
                     "rel": "bookmark"
                 }
             ], 
-            "name": "json_rack_instance", 
+            "name": "xml_rack_instance", 
             "status": "ACTIVE", 
             "volume": {
                 "size": 2
@@ -72,7 +72,7 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
     ], 
     "links": [
         {
-            "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances?marker=44b277eb-39be-4921-be31-3d61b43651d7&limit=2", 
+            "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances?marker=6396dba7-dcb6-44eb-b829-63423c31dc9e&limit=2", 
             "rel": "next"
         }
     ]

--- a/apidocs/src/resources/samples/db-instances-index-pagination-response.xml
+++ b/apidocs/src/resources/samples/db-instances-index-pagination-response.xml
@@ -2,14 +2,14 @@ HTTP/1.1 200 OK
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 1538
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:34 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 <instances xmlns="http://docs.openstack.org/database/api/v1.0">
-    <instance id="098653ba-218b-47ce-936a-e0b749101f81" name="xml_rack_instance" status="ACTIVE">
+    <instance id="4fc6f076-c0dc-48ee-ae38-9eabfc241efa" name="json_rack_instance" status="ACTIVE">
         <links>
-            <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81" rel="self"/>
-            <link href="https://ord.databases.api.rackspacecloud.com/instances/098653ba-218b-47ce-936a-e0b749101f81" rel="bookmark"/>
+            <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa" rel="self"/>
+            <link href="https://ord.databases.api.rackspacecloud.com/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa" rel="bookmark"/>
         </links>
         <volume size="2"/>
         <flavor id="1">
@@ -19,10 +19,10 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
             </links>
         </flavor>
     </instance>
-    <instance id="44b277eb-39be-4921-be31-3d61b43651d7" name="json_rack_instance" status="ACTIVE">
+    <instance id="6396dba7-dcb6-44eb-b829-63423c31dc9e" name="xml_rack_instance" status="ACTIVE">
         <links>
-            <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7" rel="self"/>
-            <link href="https://ord.databases.api.rackspacecloud.com/instances/44b277eb-39be-4921-be31-3d61b43651d7" rel="bookmark"/>
+            <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e" rel="self"/>
+            <link href="https://ord.databases.api.rackspacecloud.com/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e" rel="bookmark"/>
         </links>
         <volume size="2"/>
         <flavor id="1">
@@ -33,7 +33,7 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
         </flavor>
     </instance>
     <links>
-        <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances?marker=44b277eb-39be-4921-be31-3d61b43651d7&amp;limit=2" rel="next"/>
+        <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances?marker=6396dba7-dcb6-44eb-b829-63423c31dc9e&amp;limit=2" rel="next"/>
     </links>
 </instances>
 

--- a/apidocs/src/resources/samples/db-instances-index-response.json
+++ b/apidocs/src/resources/samples/db-instances-index-response.json
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 1038
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:34 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 {
@@ -21,18 +21,18 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
                     }
                 ]
             }, 
-            "id": "098653ba-218b-47ce-936a-e0b749101f81", 
+            "id": "4fc6f076-c0dc-48ee-ae38-9eabfc241efa", 
             "links": [
                 {
-                    "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81", 
+                    "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa", 
                     "rel": "self"
                 }, 
                 {
-                    "href": "https://ord.databases.api.rackspacecloud.com/instances/098653ba-218b-47ce-936a-e0b749101f81", 
+                    "href": "https://ord.databases.api.rackspacecloud.com/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa", 
                     "rel": "bookmark"
                 }
             ], 
-            "name": "xml_rack_instance", 
+            "name": "json_rack_instance", 
             "status": "ACTIVE", 
             "volume": {
                 "size": 2
@@ -52,18 +52,18 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
                     }
                 ]
             }, 
-            "id": "44b277eb-39be-4921-be31-3d61b43651d7", 
+            "id": "6396dba7-dcb6-44eb-b829-63423c31dc9e", 
             "links": [
                 {
-                    "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7", 
+                    "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e", 
                     "rel": "self"
                 }, 
                 {
-                    "href": "https://ord.databases.api.rackspacecloud.com/instances/44b277eb-39be-4921-be31-3d61b43651d7", 
+                    "href": "https://ord.databases.api.rackspacecloud.com/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e", 
                     "rel": "bookmark"
                 }
             ], 
-            "name": "json_rack_instance", 
+            "name": "xml_rack_instance", 
             "status": "ACTIVE", 
             "volume": {
                 "size": 2

--- a/apidocs/src/resources/samples/db-instances-index-response.xml
+++ b/apidocs/src/resources/samples/db-instances-index-response.xml
@@ -2,14 +2,14 @@ HTTP/1.1 200 OK
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 1380
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:34 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 <instances xmlns="http://docs.openstack.org/database/api/v1.0">
-    <instance id="098653ba-218b-47ce-936a-e0b749101f81" name="xml_rack_instance" status="ACTIVE">
+    <instance id="4fc6f076-c0dc-48ee-ae38-9eabfc241efa" name="json_rack_instance" status="ACTIVE">
         <links>
-            <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81" rel="self"/>
-            <link href="https://ord.databases.api.rackspacecloud.com/instances/098653ba-218b-47ce-936a-e0b749101f81" rel="bookmark"/>
+            <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa" rel="self"/>
+            <link href="https://ord.databases.api.rackspacecloud.com/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa" rel="bookmark"/>
         </links>
         <volume size="2"/>
         <flavor id="1">
@@ -19,10 +19,10 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
             </links>
         </flavor>
     </instance>
-    <instance id="44b277eb-39be-4921-be31-3d61b43651d7" name="json_rack_instance" status="ACTIVE">
+    <instance id="6396dba7-dcb6-44eb-b829-63423c31dc9e" name="xml_rack_instance" status="ACTIVE">
         <links>
-            <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7" rel="self"/>
-            <link href="https://ord.databases.api.rackspacecloud.com/instances/44b277eb-39be-4921-be31-3d61b43651d7" rel="bookmark"/>
+            <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e" rel="self"/>
+            <link href="https://ord.databases.api.rackspacecloud.com/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e" rel="bookmark"/>
         </links>
         <volume size="2"/>
         <flavor id="1">

--- a/apidocs/src/resources/samples/db-list-databases-pagination-request.json
+++ b/apidocs/src/resources/samples/db-list-databases-pagination-request.json
@@ -1,4 +1,4 @@
-GET /v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7/databases?limit=1 HTTP/1.1
+GET /v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa/databases?limit=1 HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-list-databases-pagination-request.xml
+++ b/apidocs/src/resources/samples/db-list-databases-pagination-request.xml
@@ -1,4 +1,4 @@
-GET /v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81/databases?limit=2 HTTP/1.1
+GET /v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e/databases?limit=2 HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-list-databases-pagination-response.json
+++ b/apidocs/src/resources/samples/db-list-databases-pagination-response.json
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 192
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:34 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 {
@@ -13,7 +13,7 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
     ], 
     "links": [
         {
-            "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7/databases?marker=anotherdb&limit=1", 
+            "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa/databases?marker=anotherdb&limit=1", 
             "rel": "next"
         }
     ]

--- a/apidocs/src/resources/samples/db-list-databases-pagination-response.xml
+++ b/apidocs/src/resources/samples/db-list-databases-pagination-response.xml
@@ -2,14 +2,14 @@ HTTP/1.1 200 OK
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 321
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:34 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 <databases xmlns="http://docs.openstack.org/database/api/v1.0">
     <database name="anotherdb"/>
     <database name="nextround"/>
     <links>
-        <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81/databases?marker=nextround&amp;limit=2" rel="next"/>
+        <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e/databases?marker=nextround&amp;limit=2" rel="next"/>
     </links>
 </databases>
 

--- a/apidocs/src/resources/samples/db-list-databases-request.json
+++ b/apidocs/src/resources/samples/db-list-databases-request.json
@@ -1,4 +1,4 @@
-GET /v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7/databases HTTP/1.1
+GET /v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa/databases HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-list-databases-request.xml
+++ b/apidocs/src/resources/samples/db-list-databases-request.xml
@@ -1,4 +1,4 @@
-GET /v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81/databases HTTP/1.1
+GET /v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e/databases HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-list-databases-response.json
+++ b/apidocs/src/resources/samples/db-list-databases-response.json
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 129
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:33 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 {

--- a/apidocs/src/resources/samples/db-list-databases-response.xml
+++ b/apidocs/src/resources/samples/db-list-databases-response.xml
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 241
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Date: Tue, 07 May 2013 19:35:33 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 <databases xmlns="http://docs.openstack.org/database/api/v1.0">

--- a/apidocs/src/resources/samples/db-list-user-access-request.json
+++ b/apidocs/src/resources/samples/db-list-user-access-request.json
@@ -1,5 +1,5 @@
-GET /v1.0/1234/instances/692d8418-7a8f-47f1-8060-59846c6e024f/users/exampleuser/databases HTTP/1.1
-User-Agent: python-example-client
+GET /v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa/users/dbuser1/databases HTTP/1.1
+User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7
 Accept: application/json

--- a/apidocs/src/resources/samples/db-list-user-access-request.xml
+++ b/apidocs/src/resources/samples/db-list-user-access-request.xml
@@ -1,5 +1,5 @@
-GET /v1.0/1234/instances/692d8418-7a8f-47f1-8060-59846c6e024f/users/testuser/databases HTTP/1.1
-User-Agent: python-example-client
+GET /v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e/users/dbuser1/databases HTTP/1.1
+User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7
 Accept: application/xml

--- a/apidocs/src/resources/samples/db-list-user-access-response.json
+++ b/apidocs/src/resources/samples/db-list-user-access-response.json
@@ -1,15 +1,14 @@
 HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 0
-Date: Wed, 27 Jun 2012 23:11:19 GMT
+Via: 1.1 Repose (Repose/2.6.7)
+Content-Length: 38
+Date: Tue, 07 May 2013 19:35:34 GMT
+Server: Jetty(8.0.y.z-SNAPSHOT)
 
 {
-   "databases": [
-      {
-         "name": "databaseA"
-      },
-      {
-         "name": "databaseB"
-      }
-   ]
+    "databases": [
+        {
+            "name": "databaseE"
+        }
+    ]
 }

--- a/apidocs/src/resources/samples/db-list-user-access-response.xml
+++ b/apidocs/src/resources/samples/db-list-user-access-response.xml
@@ -1,8 +1,11 @@
 HTTP/1.1 200 OK
 Content-Type: application/xml
-Content-Length: 0
-Date: Wed, 27 Jun 2012 23:11:19 GMT
+Via: 1.1 Repose (Repose/2.6.7)
+Content-Length: 110
+Date: Tue, 07 May 2013 19:35:34 GMT
+Server: Jetty(8.0.y.z-SNAPSHOT)
 
 <databases xmlns="http://docs.openstack.org/database/api/v1.0">
-    <database name="exampledb"/>
+    <database name="databaseE"/>
 </databases>
+

--- a/apidocs/src/resources/samples/db-list-users-pagination-request.json
+++ b/apidocs/src/resources/samples/db-list-users-pagination-request.json
@@ -1,4 +1,4 @@
-GET /v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7/users?limit=2 HTTP/1.1
+GET /v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa/users?limit=2 HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-list-users-pagination-request.xml
+++ b/apidocs/src/resources/samples/db-list-users-pagination-request.xml
@@ -1,4 +1,4 @@
-GET /v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81/users?limit=2 HTTP/1.1
+GET /v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e/users?limit=2 HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-list-users-pagination-response.json
+++ b/apidocs/src/resources/samples/db-list-users-pagination-response.json
@@ -1,20 +1,21 @@
 HTTP/1.1 200 OK
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
-Content-Length: 279
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Content-Length: 323
+Date: Tue, 07 May 2013 19:35:34 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 {
     "links": [
         {
-            "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7/users?marker=dbuser2&limit=2", 
+            "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa/users?marker=dbuser2%4010.0.0.1&limit=2", 
             "rel": "next"
         }
     ], 
     "users": [
         {
             "databases": [], 
+            "host": "%", 
             "name": "dbuser1"
         }, 
         {
@@ -26,6 +27,7 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
                     "name": "databaseC"
                 }
             ], 
+            "host": "10.0.0.1", 
             "name": "dbuser2"
         }
     ]

--- a/apidocs/src/resources/samples/db-list-users-pagination-response.xml
+++ b/apidocs/src/resources/samples/db-list-users-pagination-response.xml
@@ -1,22 +1,22 @@
 HTTP/1.1 200 OK
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
-Content-Length: 461
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Content-Length: 497
+Date: Tue, 07 May 2013 19:35:34 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 <users xmlns="http://docs.openstack.org/database/api/v1.0">
-    <user name="dbuser1">
+    <user host="%" name="dbuser1">
         <databases/>
     </user>
-    <user name="dbuser2">
+    <user host="10.0.0.1" name="dbuser2">
         <databases>
             <database name="databaseB"/>
             <database name="databaseC"/>
         </databases>
     </user>
     <links>
-        <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81/users?marker=dbuser2&amp;limit=2" rel="next"/>
+        <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e/users?marker=dbuser2%4010.0.0.1&amp;limit=2" rel="next"/>
     </links>
 </users>
 

--- a/apidocs/src/resources/samples/db-list-users-request.json
+++ b/apidocs/src/resources/samples/db-list-users-request.json
@@ -1,4 +1,4 @@
-GET /v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7/users HTTP/1.1
+GET /v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa/users HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-list-users-request.xml
+++ b/apidocs/src/resources/samples/db-list-users-request.xml
@@ -1,4 +1,4 @@
-GET /v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81/users HTTP/1.1
+GET /v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e/users HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-list-users-response.json
+++ b/apidocs/src/resources/samples/db-list-users-response.json
@@ -1,14 +1,15 @@
 HTTP/1.1 200 OK
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
-Content-Length: 228
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Content-Length: 287
+Date: Tue, 07 May 2013 19:35:34 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 {
     "users": [
         {
             "databases": [], 
+            "host": "%", 
             "name": "dbuser1"
         }, 
         {
@@ -20,10 +21,12 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
                     "name": "databaseC"
                 }
             ], 
+            "host": "10.0.0.1", 
             "name": "dbuser2"
         }, 
         {
             "databases": [], 
+            "host": "%", 
             "name": "dbuser3"
         }, 
         {
@@ -32,6 +35,7 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
                     "name": "sampledb"
                 }
             ], 
+            "host": "%", 
             "name": "demouser"
         }
     ]

--- a/apidocs/src/resources/samples/db-list-users-response.xml
+++ b/apidocs/src/resources/samples/db-list-users-response.xml
@@ -1,24 +1,24 @@
 HTTP/1.1 200 OK
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
-Content-Length: 468
-Date: Mon, 18 Mar 2013 19:09:17 GMT
+Content-Length: 511
+Date: Tue, 07 May 2013 19:35:34 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 <users xmlns="http://docs.openstack.org/database/api/v1.0">
-    <user name="dbuser1">
+    <user host="%" name="dbuser1">
         <databases/>
     </user>
-    <user name="dbuser2">
+    <user host="10.0.0.1" name="dbuser2">
         <databases>
             <database name="databaseB"/>
             <database name="databaseC"/>
         </databases>
     </user>
-    <user name="dbuser3">
+    <user host="%" name="dbuser3">
         <databases/>
     </user>
-    <user name="demouser">
+    <user host="%" name="demouser">
         <databases>
             <database name="sampledb"/>
         </databases>

--- a/apidocs/src/resources/samples/db-mgmt-get-account-details-response.json
+++ b/apidocs/src/resources/samples/db-mgmt-get-account-details-response.json
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 283
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:36 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 {
@@ -11,13 +11,13 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
         "instances": [
             {
                 "host": "hostname_1", 
-                "id": "44b277eb-39be-4921-be31-3d61b43651d7", 
+                "id": "4fc6f076-c0dc-48ee-ae38-9eabfc241efa", 
                 "name": "json_rack_instance", 
                 "status": "ACTIVE"
             }, 
             {
                 "host": "hostname_1", 
-                "id": "098653ba-218b-47ce-936a-e0b749101f81", 
+                "id": "6396dba7-dcb6-44eb-b829-63423c31dc9e", 
                 "name": "xml_rack_instance", 
                 "status": "ACTIVE"
             }

--- a/apidocs/src/resources/samples/db-mgmt-get-account-details-response.xml
+++ b/apidocs/src/resources/samples/db-mgmt-get-account-details-response.xml
@@ -2,13 +2,13 @@ HTTP/1.1 200 OK
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 361
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:36 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 <account id="3000" xmlns="http://docs.openstack.org/database/api/v1.0">
     <instances>
-        <instance host="hostname_1" id="44b277eb-39be-4921-be31-3d61b43651d7" name="json_rack_instance" status="ACTIVE"/>
-        <instance host="hostname_1" id="098653ba-218b-47ce-936a-e0b749101f81" name="xml_rack_instance" status="ACTIVE"/>
+        <instance host="hostname_1" id="4fc6f076-c0dc-48ee-ae38-9eabfc241efa" name="json_rack_instance" status="ACTIVE"/>
+        <instance host="hostname_1" id="6396dba7-dcb6-44eb-b829-63423c31dc9e" name="xml_rack_instance" status="ACTIVE"/>
     </instances>
 </account>
 

--- a/apidocs/src/resources/samples/db-mgmt-get-host-detail-response.json
+++ b/apidocs/src/resources/samples/db-mgmt-get-host-detail-response.json
@@ -2,23 +2,23 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 456
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:35 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 {
     "host": {
         "instances": [
             {
-                "id": "44b277eb-39be-4921-be31-3d61b43651d7", 
+                "id": "4fc6f076-c0dc-48ee-ae38-9eabfc241efa", 
                 "name": "json_rack_instance", 
-                "server_id": "48996795-5fd8-4bf7-8b33-3824a86f3b19", 
+                "server_id": "6e01d387-449f-4e10-ac86-53399f08fbad", 
                 "status": "ACTIVE", 
                 "tenant_id": "3000"
             }, 
             {
-                "id": "098653ba-218b-47ce-936a-e0b749101f81", 
+                "id": "6396dba7-dcb6-44eb-b829-63423c31dc9e", 
                 "name": "xml_rack_instance", 
-                "server_id": "b3aca411-ef1c-4c47-88d3-5a309096c204", 
+                "server_id": "59de80b2-3b99-4804-af53-26474288b6a5", 
                 "status": "ACTIVE", 
                 "tenant_id": "3000"
             }

--- a/apidocs/src/resources/samples/db-mgmt-get-host-detail-response.xml
+++ b/apidocs/src/resources/samples/db-mgmt-get-host-detail-response.xml
@@ -2,13 +2,13 @@ HTTP/1.1 200 OK
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 517
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:36 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 <host name="hostname_1" percentUsed="204" totalRAM="2004" usedRAM="4096" xmlns="http://docs.openstack.org/database/api/v1.0">
     <instances>
-        <instance id="44b277eb-39be-4921-be31-3d61b43651d7" name="json_rack_instance" server_id="48996795-5fd8-4bf7-8b33-3824a86f3b19" status="ACTIVE" tenant_id="3000"/>
-        <instance id="098653ba-218b-47ce-936a-e0b749101f81" name="xml_rack_instance" server_id="b3aca411-ef1c-4c47-88d3-5a309096c204" status="ACTIVE" tenant_id="3000"/>
+        <instance id="4fc6f076-c0dc-48ee-ae38-9eabfc241efa" name="json_rack_instance" server_id="6e01d387-449f-4e10-ac86-53399f08fbad" status="ACTIVE" tenant_id="3000"/>
+        <instance id="6396dba7-dcb6-44eb-b829-63423c31dc9e" name="xml_rack_instance" server_id="59de80b2-3b99-4804-af53-26474288b6a5" status="ACTIVE" tenant_id="3000"/>
     </instances>
 </host>
 

--- a/apidocs/src/resources/samples/db-mgmt-get-instance-details-request.json
+++ b/apidocs/src/resources/samples/db-mgmt-get-instance-details-request.json
@@ -1,4 +1,4 @@
-GET /v1.0/1234/mgmt/instances/44b277eb-39be-4921-be31-3d61b43651d7 HTTP/1.1
+GET /v1.0/1234/mgmt/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-mgmt-get-instance-details-request.xml
+++ b/apidocs/src/resources/samples/db-mgmt-get-instance-details-request.xml
@@ -1,4 +1,4 @@
-GET /v1.0/1234/mgmt/instances/098653ba-218b-47ce-936a-e0b749101f81 HTTP/1.1
+GET /v1.0/1234/mgmt/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-mgmt-get-instance-details-response.json
+++ b/apidocs/src/resources/samples/db-mgmt-get-instance-details-response.json
@@ -2,12 +2,12 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 1404
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:36 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 {
     "instance": {
-        "created": "2013-03-18T19:09:17", 
+        "created": "2013-05-07T19:35:33", 
         "deleted": false, 
         "deleted_at": null, 
         "flavor": {
@@ -26,19 +26,19 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
         "guest_status": {
             "state_description": "running"
         }, 
-        "id": "44b277eb-39be-4921-be31-3d61b43651d7", 
+        "id": "4fc6f076-c0dc-48ee-ae38-9eabfc241efa", 
         "links": [
             {
-                "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7", 
+                "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa", 
                 "rel": "self"
             }, 
             {
-                "href": "https://ord.databases.api.rackspacecloud.com/instances/44b277eb-39be-4921-be31-3d61b43651d7", 
+                "href": "https://ord.databases.api.rackspacecloud.com/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa", 
                 "rel": "bookmark"
             }
         ], 
         "name": "json_rack_instance", 
-        "root_enabled": "2013-03-18T19:09:17", 
+        "root_enabled": "2013-05-07T19:35:34", 
         "root_enabled_by": null, 
         "server": {
             "addresses": {
@@ -51,7 +51,7 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
             "deleted": false, 
             "deleted_at": null, 
             "host": "hostname_1", 
-            "id": "48996795-5fd8-4bf7-8b33-3824a86f3b19", 
+            "id": "6e01d387-449f-4e10-ac86-53399f08fbad", 
             "local_id": 0, 
             "name": "json_rack_instance", 
             "status": "ACTIVE", 
@@ -61,17 +61,17 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
         "status": "ACTIVE", 
         "task_description": "No tasks for the instance.", 
         "tenant_id": "3000", 
-        "updated": "2013-03-18T19:09:18", 
+        "updated": "2013-05-07T19:35:35", 
         "volume": {
             "attachments": [
                 {
                     "device": "vdb", 
-                    "server_id": "48996795-5fd8-4bf7-8b33-3824a86f3b19"
+                    "server_id": "6e01d387-449f-4e10-ac86-53399f08fbad"
                 }
             ], 
             "availability_zone": "fake-availability-zone", 
             "created_at": "2001-01-01-12:30:30", 
-            "id": "VOL_70110787-f822-4cdf-8ead-44d25082befd", 
+            "id": "VOL_241d0651-b376-4d7c-a0cb-d0136b708149", 
             "size": 4, 
             "status": "in-use", 
             "used": 0.16368598397821188

--- a/apidocs/src/resources/samples/db-mgmt-get-instance-details-response.xml
+++ b/apidocs/src/resources/samples/db-mgmt-get-instance-details-response.xml
@@ -2,13 +2,13 @@ HTTP/1.1 200 OK
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 2401
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:36 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
-<instance created="2013-03-18 19:09:17.441489" deleted="False" deleted_at="None" id="098653ba-218b-47ce-936a-e0b749101f81" name="xml_rack_instance" status="ACTIVE" task_description="No tasks for the instance." tenant_id="3000" updated="2013-03-18 19:09:18.280855" xmlns="http://docs.openstack.org/database/api/v1.0">
+<instance created="2013-05-07 19:35:33.539799" deleted="False" deleted_at="None" id="6396dba7-dcb6-44eb-b829-63423c31dc9e" name="xml_rack_instance" status="ACTIVE" task_description="No tasks for the instance." tenant_id="3000" updated="2013-05-07 19:35:35.919427" xmlns="http://docs.openstack.org/database/api/v1.0">
     <links>
-        <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81" rel="self"/>
-        <link href="https://ord.databases.api.rackspacecloud.com/instances/098653ba-218b-47ce-936a-e0b749101f81" rel="bookmark"/>
+        <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e" rel="self"/>
+        <link href="https://ord.databases.api.rackspacecloud.com/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e" rel="bookmark"/>
     </links>
     <server>
         <status>
@@ -33,7 +33,7 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
             None
         </deleted_at>
         <id>
-            b3aca411-ef1c-4c47-88d3-5a309096c204
+            59de80b2-3b99-4804-af53-26474288b6a5
         </id>
         <addresses>
             <private>
@@ -45,7 +45,7 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
             </private>
         </addresses>
     </server>
-    <volume id="VOL_d3870ed4-3f5b-4b78-8ce4-c81f35f0fe2c" size="4" used="0.163685983978">
+    <volume id="VOL_73a3f2b8-bbd8-4f97-a43d-6d714a1d519b" size="4" used="0.163685983978">
         <status>
             in-use
         </status>
@@ -55,7 +55,7 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
                     vdb
                 </device>
                 <server_id>
-                    b3aca411-ef1c-4c47-88d3-5a309096c204
+                    59de80b2-3b99-4804-af53-26474288b6a5
                 </server_id>
             </attachment>
         </attachments>
@@ -71,7 +71,7 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
         ACTIVE
     </service_status>
     <root_enabled>
-        2013-03-18 19:09:17.772833
+        2013-05-07 19:35:34.457268
     </root_enabled>
     <flavor id="3">
         <links>

--- a/apidocs/src/resources/samples/db-mgmt-get-root-details-request.json
+++ b/apidocs/src/resources/samples/db-mgmt-get-root-details-request.json
@@ -1,4 +1,4 @@
-GET /v1.0/1234/mgmt/instances/44b277eb-39be-4921-be31-3d61b43651d7/root HTTP/1.1
+GET /v1.0/1234/mgmt/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa/root HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-mgmt-get-root-details-request.xml
+++ b/apidocs/src/resources/samples/db-mgmt-get-root-details-request.xml
@@ -1,4 +1,4 @@
-GET /v1.0/1234/mgmt/instances/098653ba-218b-47ce-936a-e0b749101f81/root HTTP/1.1
+GET /v1.0/1234/mgmt/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e/root HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-mgmt-get-root-details-response.json
+++ b/apidocs/src/resources/samples/db-mgmt-get-root-details-response.json
@@ -2,13 +2,13 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 112
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:36 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 {
     "root_history": {
-        "enabled": "2013-03-18T19:09:17", 
-        "id": "44b277eb-39be-4921-be31-3d61b43651d7", 
+        "enabled": "2013-05-07T19:35:34", 
+        "id": "4fc6f076-c0dc-48ee-ae38-9eabfc241efa", 
         "user": null
     }
 }

--- a/apidocs/src/resources/samples/db-mgmt-get-root-details-response.xml
+++ b/apidocs/src/resources/samples/db-mgmt-get-root-details-response.xml
@@ -2,8 +2,8 @@ HTTP/1.1 200 OK
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 159
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:36 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
-<root_history enabled="2013-03-18 19:09:17.772833" id="098653ba-218b-47ce-936a-e0b749101f81" user="None" xmlns="http://docs.openstack.org/database/api/v1.0"/>
+<root_history enabled="2013-05-07 19:35:34.457268" id="6396dba7-dcb6-44eb-b829-63423c31dc9e" user="None" xmlns="http://docs.openstack.org/database/api/v1.0"/>
 

--- a/apidocs/src/resources/samples/db-mgmt-get-storage-response.json
+++ b/apidocs/src/resources/samples/db-mgmt-get-storage-response.json
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 177
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:36 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 {

--- a/apidocs/src/resources/samples/db-mgmt-get-storage-response.xml
+++ b/apidocs/src/resources/samples/db-mgmt-get-storage-response.xml
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 254
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:36 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 <devices xmlns="http://docs.openstack.org/database/api/v1.0">

--- a/apidocs/src/resources/samples/db-mgmt-instance-diagnostics-request.json
+++ b/apidocs/src/resources/samples/db-mgmt-instance-diagnostics-request.json
@@ -1,4 +1,4 @@
-GET /v1.0/1234/mgmt/instances/44b277eb-39be-4921-be31-3d61b43651d7/diagnostics HTTP/1.1
+GET /v1.0/1234/mgmt/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa/diagnostics HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-mgmt-instance-diagnostics-request.xml
+++ b/apidocs/src/resources/samples/db-mgmt-instance-diagnostics-request.xml
@@ -1,4 +1,4 @@
-GET /v1.0/1234/mgmt/instances/098653ba-218b-47ce-936a-e0b749101f81/diagnostics HTTP/1.1
+GET /v1.0/1234/mgmt/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e/diagnostics HTTP/1.1
 User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7

--- a/apidocs/src/resources/samples/db-mgmt-instance-diagnostics-response.json
+++ b/apidocs/src/resources/samples/db-mgmt-instance-diagnostics-response.json
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 125
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:36 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 {

--- a/apidocs/src/resources/samples/db-mgmt-instance-diagnostics-response.xml
+++ b/apidocs/src/resources/samples/db-mgmt-instance-diagnostics-response.xml
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 159
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:36 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 <diagnostics fdSize="64" threads="2" version="1" vmHwm="2872" vmPeak="29160" vmRss="2872" vmSize="29096" xmlns="http://docs.openstack.org/database/api/v1.0"/>

--- a/apidocs/src/resources/samples/db-mgmt-instance-index-response.json
+++ b/apidocs/src/resources/samples/db-mgmt-instance-index-response.json
@@ -2,13 +2,13 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 1891
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:36 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 {
     "instances": [
         {
-            "created": "2013-03-18T19:09:17", 
+            "created": "2013-05-07T19:35:33", 
             "deleted": false, 
             "deleted_at": null, 
             "flavor": {
@@ -24,14 +24,14 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
                     }
                 ]
             }, 
-            "id": "44b277eb-39be-4921-be31-3d61b43651d7", 
+            "id": "4fc6f076-c0dc-48ee-ae38-9eabfc241efa", 
             "links": [
                 {
-                    "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7", 
+                    "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa", 
                     "rel": "self"
                 }, 
                 {
-                    "href": "https://ord.databases.api.rackspacecloud.com/instances/44b277eb-39be-4921-be31-3d61b43651d7", 
+                    "href": "https://ord.databases.api.rackspacecloud.com/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa", 
                     "rel": "bookmark"
                 }
             ], 
@@ -40,7 +40,7 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
                 "deleted": false, 
                 "deleted_at": null, 
                 "host": "hostname_1", 
-                "id": "48996795-5fd8-4bf7-8b33-3824a86f3b19", 
+                "id": "6e01d387-449f-4e10-ac86-53399f08fbad", 
                 "local_id": 0, 
                 "name": "json_rack_instance", 
                 "status": "ACTIVE", 
@@ -50,13 +50,13 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
             "status": "ACTIVE", 
             "task_description": "No tasks for the instance.", 
             "tenant_id": "3000", 
-            "updated": "2013-03-18T19:09:18", 
+            "updated": "2013-05-07T19:35:35", 
             "volume": {
                 "size": 4
             }
         }, 
         {
-            "created": "2013-03-18T19:09:17", 
+            "created": "2013-05-07T19:35:33", 
             "deleted": false, 
             "deleted_at": null, 
             "flavor": {
@@ -72,14 +72,14 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
                     }
                 ]
             }, 
-            "id": "098653ba-218b-47ce-936a-e0b749101f81", 
+            "id": "6396dba7-dcb6-44eb-b829-63423c31dc9e", 
             "links": [
                 {
-                    "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81", 
+                    "href": "https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e", 
                     "rel": "self"
                 }, 
                 {
-                    "href": "https://ord.databases.api.rackspacecloud.com/instances/098653ba-218b-47ce-936a-e0b749101f81", 
+                    "href": "https://ord.databases.api.rackspacecloud.com/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e", 
                     "rel": "bookmark"
                 }
             ], 
@@ -88,7 +88,7 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
                 "deleted": false, 
                 "deleted_at": null, 
                 "host": "hostname_1", 
-                "id": "b3aca411-ef1c-4c47-88d3-5a309096c204", 
+                "id": "59de80b2-3b99-4804-af53-26474288b6a5", 
                 "local_id": 0, 
                 "name": "xml_rack_instance", 
                 "status": "ACTIVE", 
@@ -98,7 +98,7 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
             "status": "ACTIVE", 
             "task_description": "No tasks for the instance.", 
             "tenant_id": "3000", 
-            "updated": "2013-03-18T19:09:18", 
+            "updated": "2013-05-07T19:35:35", 
             "volume": {
                 "size": 4
             }

--- a/apidocs/src/resources/samples/db-mgmt-instance-index-response.xml
+++ b/apidocs/src/resources/samples/db-mgmt-instance-index-response.xml
@@ -2,14 +2,14 @@ HTTP/1.1 200 OK
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 3103
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:36 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 <instances xmlns="http://docs.openstack.org/database/api/v1.0">
-    <instance created="2013-03-18 19:09:17.409294" deleted="False" deleted_at="None" id="44b277eb-39be-4921-be31-3d61b43651d7" name="json_rack_instance" status="ACTIVE" task_description="No tasks for the instance." tenant_id="3000" updated="2013-03-18 19:09:18.248643">
+    <instance created="2013-05-07 19:35:33.360398" deleted="False" deleted_at="None" id="4fc6f076-c0dc-48ee-ae38-9eabfc241efa" name="json_rack_instance" status="ACTIVE" task_description="No tasks for the instance." tenant_id="3000" updated="2013-05-07 19:35:35.847678">
         <links>
-            <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/44b277eb-39be-4921-be31-3d61b43651d7" rel="self"/>
-            <link href="https://ord.databases.api.rackspacecloud.com/instances/44b277eb-39be-4921-be31-3d61b43651d7" rel="bookmark"/>
+            <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa" rel="self"/>
+            <link href="https://ord.databases.api.rackspacecloud.com/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa" rel="bookmark"/>
         </links>
         <server>
             <status>
@@ -34,7 +34,7 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
                 None
             </deleted_at>
             <id>
-                48996795-5fd8-4bf7-8b33-3824a86f3b19
+                6e01d387-449f-4e10-ac86-53399f08fbad
             </id>
         </server>
         <volume size="4"/>
@@ -48,10 +48,10 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
             </links>
         </flavor>
     </instance>
-    <instance created="2013-03-18 19:09:17.441489" deleted="False" deleted_at="None" id="098653ba-218b-47ce-936a-e0b749101f81" name="xml_rack_instance" status="ACTIVE" task_description="No tasks for the instance." tenant_id="3000" updated="2013-03-18 19:09:18.280855">
+    <instance created="2013-05-07 19:35:33.539799" deleted="False" deleted_at="None" id="6396dba7-dcb6-44eb-b829-63423c31dc9e" name="xml_rack_instance" status="ACTIVE" task_description="No tasks for the instance." tenant_id="3000" updated="2013-05-07 19:35:35.919427">
         <links>
-            <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/098653ba-218b-47ce-936a-e0b749101f81" rel="self"/>
-            <link href="https://ord.databases.api.rackspacecloud.com/instances/098653ba-218b-47ce-936a-e0b749101f81" rel="bookmark"/>
+            <link href="https://ord.databases.api.rackspacecloud.com/v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e" rel="self"/>
+            <link href="https://ord.databases.api.rackspacecloud.com/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e" rel="bookmark"/>
         </links>
         <server>
             <status>
@@ -76,7 +76,7 @@ Server: Jetty(8.0.y.z-SNAPSHOT)
                 None
             </deleted_at>
             <id>
-                b3aca411-ef1c-4c47-88d3-5a309096c204
+                59de80b2-3b99-4804-af53-26474288b6a5
             </id>
         </server>
         <volume size="4"/>

--- a/apidocs/src/resources/samples/db-mgmt-list-accounts-response.json
+++ b/apidocs/src/resources/samples/db-mgmt-list-accounts-response.json
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 50
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:36 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 {

--- a/apidocs/src/resources/samples/db-mgmt-list-accounts-response.xml
+++ b/apidocs/src/resources/samples/db-mgmt-list-accounts-response.xml
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 118
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:36 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 <accounts xmlns="http://docs.openstack.org/database/api/v1.0">

--- a/apidocs/src/resources/samples/db-mgmt-list-hosts-response.json
+++ b/apidocs/src/resources/samples/db-mgmt-list-hosts-response.json
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 101
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:36 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 {

--- a/apidocs/src/resources/samples/db-mgmt-list-hosts-response.xml
+++ b/apidocs/src/resources/samples/db-mgmt-list-hosts-response.xml
@@ -2,7 +2,7 @@ HTTP/1.1 200 OK
 Content-Type: application/xml
 Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 167
-Date: Mon, 18 Mar 2013 19:09:18 GMT
+Date: Tue, 07 May 2013 19:35:36 GMT
 Server: Jetty(8.0.y.z-SNAPSHOT)
 
 <hosts xmlns="http://docs.openstack.org/database/api/v1.0">

--- a/apidocs/src/resources/samples/db-revoke-user-access-request.json
+++ b/apidocs/src/resources/samples/db-revoke-user-access-request.json
@@ -1,5 +1,5 @@
-DELETE /v1.0/1234/instances/692d8418-7a8f-47f1-8060-59846c6e024f/users/exampleuser/databases/databaseC HTTP/1.1
-User-Agent: python-example-client
+DELETE /v1.0/1234/instances/4fc6f076-c0dc-48ee-ae38-9eabfc241efa/users/dbuser1/databases/databaseE HTTP/1.1
+User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7
 Accept: application/json

--- a/apidocs/src/resources/samples/db-revoke-user-access-request.xml
+++ b/apidocs/src/resources/samples/db-revoke-user-access-request.xml
@@ -1,5 +1,5 @@
-DELETE /v1.0/1234/instances/692d8418-7a8f-47f1-8060-59846c6e024f/users/testuser/databases/extradb HTTP/1.1
-User-Agent: python-example-client
+DELETE /v1.0/1234/instances/6396dba7-dcb6-44eb-b829-63423c31dc9e/users/dbuser1/databases/databaseE HTTP/1.1
+User-Agent: python-reddwarfclient
 Host: ord.databases.api.rackspacecloud.com
 X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7
 Accept: application/xml

--- a/apidocs/src/resources/samples/db-revoke-user-access-response.json
+++ b/apidocs/src/resources/samples/db-revoke-user-access-response.json
@@ -1,4 +1,6 @@
 HTTP/1.1 202 Accepted
 Content-Type: application/json
+Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 0
-Date: Wed, 27 Jun 2012 23:11:19 GMT
+Date: Tue, 07 May 2013 19:35:34 GMT
+Server: Jetty(8.0.y.z-SNAPSHOT)

--- a/apidocs/src/resources/samples/db-revoke-user-access-response.xml
+++ b/apidocs/src/resources/samples/db-revoke-user-access-response.xml
@@ -1,4 +1,6 @@
 HTTP/1.1 202 Accepted
 Content-Type: application/xml
+Via: 1.1 Repose (Repose/2.6.7)
 Content-Length: 0
-Date: Wed, 27 Jun 2012 23:11:19 GMT
+Date: Tue, 07 May 2013 19:35:34 GMT
+Server: Jetty(8.0.y.z-SNAPSHOT)


### PR DESCRIPTION
Regenerated examples after adding generators for user access calls, and including the new hostname parameter in requests and responses that mention users.

This was based off of branch docupdates_sp32a as that seemed to be the most recent one. If you prefer, I can instead scrap this and submit a pull request to your master branch.
