### PR TITLE
Example files for Modify User Attributes API call

### DIFF
--- a/apidocs/src/resources/samples/db-change-user-attributes-request.json
+++ b/apidocs/src/resources/samples/db-change-user-attributes-request.json
@@ -1,0 +1,13 @@
+PUT /v1.0/1234/instances/8ed28d4b-9b70-46cc-97cd-2e4bf4b17b73/users/dbuser1 HTTP/1.1
+User-Agent: python-troveclient
+Host: ord.databases.api.rackspacecloud.com
+X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7
+Accept: application/json
+Content-Type: application/json
+
+{
+    "user": {
+        "name": "new_username", 
+        "password": "new_password"
+    }
+}

--- a/apidocs/src/resources/samples/db-change-user-attributes-request.xml
+++ b/apidocs/src/resources/samples/db-change-user-attributes-request.xml
@@ -1,0 +1,9 @@
+PUT /v1.0/1234/instances/f791bfed-877c-40ac-9685-14a142807651/users/dbuser1 HTTP/1.1
+User-Agent: python-troveclient
+Host: ord.databases.api.rackspacecloud.com
+X-Auth-Token: 87c6033c-9ff6-405f-943e-2deb73f278b7
+Accept: application/xml
+Content-Type: application/xml
+
+<user xmlns="http://docs.openstack.org/database/api/v1.0" password="new_password" name="new_username"/>
+

--- a/apidocs/src/resources/samples/db-change-user-attributes-response.json
+++ b/apidocs/src/resources/samples/db-change-user-attributes-response.json
@@ -1,0 +1,6 @@
+HTTP/1.1 202 Accepted
+Content-Type: application/json
+Via: 1.1 Repose (Repose/2.6.7)
+Content-Length: 0
+Date: Tue, 06 Aug 2013 16:24:59 GMT
+Server: Jetty(8.0.y.z-SNAPSHOT)

--- a/apidocs/src/resources/samples/db-change-user-attributes-response.xml
+++ b/apidocs/src/resources/samples/db-change-user-attributes-response.xml
@@ -1,0 +1,6 @@
+HTTP/1.1 202 Accepted
+Content-Type: application/xml
+Via: 1.1 Repose (Repose/2.6.7)
+Content-Length: 0
+Date: Tue, 06 Aug 2013 16:24:59 GMT
+Server: Jetty(8.0.y.z-SNAPSHOT)


### PR DESCRIPTION
At present, when a Cloud Database user creates a username, password and hostname for a database user,
he does not have the ability to modify these user attributes.
This API enables the Cloud DB user to make changes to one or more of these user attributes (username,hostname,password).
This commit includes the addition of relevant example JSON and XML request-repsonse files

Implements: blueprint modify-userattributes
